### PR TITLE
configure the preference name through the LazyPref annotation

### DIFF
--- a/lazypref-annotations/src/main/java/com/freddieptf/lazyprefannotations/LazyPref.java
+++ b/lazypref-annotations/src/main/java/com/freddieptf/lazyprefannotations/LazyPref.java
@@ -11,4 +11,7 @@ import java.lang.annotation.Target;
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.SOURCE)
 public @interface LazyPref {
+
+    String preferenceName() default ""; // Name of the preference file to be created
+
 }

--- a/lazypref-compiler/src/main/java/com/freddieptf/lazyprefcompiler/LazyPrefProcessor.java
+++ b/lazypref-compiler/src/main/java/com/freddieptf/lazyprefcompiler/LazyPrefProcessor.java
@@ -125,7 +125,9 @@ public class LazyPrefProcessor extends AbstractProcessor {
     private boolean processLazyPrefInterface(TypeElement element) {
         String pkgName = getPkgName(element);
         String className = getKlasName(element, pkgName) + LazyBaby.LAZY_SUFFIX;
+        String preferenceName = element.getAnnotation(LazyPref.class).preferenceName();
         LazyBaby.Builder builder = new LazyBaby.Builder(pkgName, className)
+                .setPreferenceName(preferenceName)
                 .buildClass();
         // sanity check needed? idk..
         element.getEnclosedElements()


### PR DESCRIPTION
Configure the preference name through the LazyPref annotation. If it's set we create a shared preferences with the preference name, if not we use the default shared preferences.